### PR TITLE
Suggest improvements for the Counter Tutorial

### DIFF
--- a/bindings/package-lock.json
+++ b/bindings/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@croquet/react",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@croquet/react",
-      "version": "1.4.3",
-      "license": "ISC",
+      "version": "1.4.4",
+      "license": "Apatch-2.0",
       "dependencies": {
-        "@croquet/croquet": "^1.1.0-42"
+        "@croquet/croquet": "^1.1.0-43"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@croquet/croquet": {
-      "version": "1.1.0-42",
-      "resolved": "https://registry.npmjs.org/@croquet/croquet/-/croquet-1.1.0-42.tgz",
-      "integrity": "sha512-e0KkAMlpZgxSQrRMqn8G9iOpWzKSrnAEc62aZRLDla/Z+Ss1aZWK8xZv+zxLKc6f04VEw4iWeLf84u/XZno5Rg=="
+      "version": "1.1.0-43",
+      "resolved": "https://registry.npmjs.org/@croquet/croquet/-/croquet-1.1.0-43.tgz",
+      "integrity": "sha512-RlCz6zqrhnLvdm4mmoRU+qybhJHbso45my6j9lXSFnoQMrHNOIsnuei1hkUPEAb/gcbmFzcjwrhEv2cMCLhBTw=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -65,8 +65,8 @@ CounterModel.register("CounterModel");
 Now, we define the `CounterApp`, which will be our top level React component.
 We use the `InCroquetSession` component to provide the running Croquet session to its children.
 This component takes the role of the [`Session.join`](../croquet/Session.html#.join) method in `@croquet/croquet`, and can be configured with the same parameters.
-We recommend using environment variables to configure them.
-If you use a different bundler, check their documentation on how to set them up.
+We recommend specifying those values in environment variables, since it would make those values more secure and easier to maintain.
+For more information about this topic, feel free to check out [this article](https://kinsta.com/knowledgebase/what-is-an-environment-variable/).
 
 ```
 function CounterApp() {

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -64,7 +64,7 @@ CounterModel.register("CounterModel");
 
 Now, we define the `CounterApp`, which will be our top level React component.
 We use the `InCroquetSession` component to provide the running Croquet session to its children.
-This component takes the role of the `Session.join` method in `@croquet/croquet`, and can be configured with the same parameters.
+This component takes the role of the [`Session.join`](../croquet/Session.html#.join) method in `@croquet/croquet`, and can be configured with the same parameters.
 We recommend using environment variables to configure them.
 If you use a different bundler, check their documentation on how to set them up.
 

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -65,7 +65,7 @@ CounterModel.register("CounterModel");
 Now, we define the `CounterApp`, which will be our top level React component.
 We use the `InCroquetSession` component to provide the running Croquet session to its children.
 This component takes the role of the [`Session.join`](../croquet/Session.html#.join) method in `@croquet/croquet`, and can be configured with the same parameters.
-We recommend specifying those values in environment variables, since it would make those values more secure and easier to maintain.
+We recommend specifying those values in environment variables so that it's easier to manage them (e.g. switching between development and production keys).
 For more information about this topic, feel free to check out [this article](https://kinsta.com/knowledgebase/what-is-an-environment-variable/).
 
 ```

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -18,7 +18,7 @@ import { Model } from "@croquet/croquet";
 import {
   usePublish,
   useModelRoot,
-  InCroquetSession,
+  CroquetRoot,
   useSubscribe,
   Model
 } from "@croquet/react";
@@ -70,19 +70,21 @@ For more information about this topic, feel free to check out [this article](htt
 
 ```
 function CounterApp() {
-  const appId = import.meta.env["VITE_CROQUET_APP_ID"] || CroquetApp.autoSession("q");
-  const apiKey = import.meta.env["VITE_CROQUET_API_KEY"];
   return (
-    <InCroquetSession
-      name="counter"
-      apiKey={apiKey}
-      appId={appId}
-      password="abc"
-      model={CounterModel}>
+    <CroquetRoot
+      sessionParams={{
+        name: "counter",
+        model: CounterModel,
+        appId: import.meta.env["VITE_CROQUET_APP_ID"] || CroquetApp.autoSession("q"),
+        apiKey: import.meta.env["VITE_CROQUET_API_KEY"],
+        password: "abc",
+      }}
+    >
       <CounterDisplay />
-    </InCroquetSession>
+    </CroquetRoot>
   );
 }
+
 ```
 
 Next, we define the `CounterDisplay` component, which represents a view of the model defined above.

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -1,6 +1,7 @@
 {@link top.md}
 
 This tutorial directly corresponds to the ["Hello World" tutorial](../croquet/tutorial-1_1_hello_world.html) of the Croquet Library. In fact the model side looks exactly the same. The following document assumes you are familiar with the main concepts presented there.
+The source code for this tutorial is available on [Github](https://github.com/croquet/react-croquet-counter).
 
 The following example uses [Vite](https://vitejs.dev) for build. Other bundlers work fine also, but Vite is easy to get started as of writing in early 2024.
 
@@ -8,9 +9,7 @@ The following example uses [Vite](https://vitejs.dev) for build. Other bundlers 
      style="width:60%; height:500px; border:1; border-radius: 4px; overflow:hidden;"
 ></iframe>
 
-The source code is available on [Github](https://github.com/croquet/react-croquet-counter).
-
-We start by importing React and Croquet Library here as npm dependencies.
+We start by creating a file `main.jsx`, and importing the required dependencies:
 
 ```
 import ReactDOM from "react-dom/client";
@@ -25,7 +24,15 @@ import {
 } from "@croquet/react";
 ```
 
-The `CounterModel` has one state called "count" (`this.count`), and it publishes a message called "count" when the value of count changes. A common practice for the message scope (the first argument) is to use `this.id` to indicate that this particular model's `count` has been changed or requested to be reset.
+We then define the `CounterModel` class.
+It has one attribute called "count" (`this.count`), and two methods: `resetCounter` and `tick`.
+When the object is being initialized, we set the initial counter value to zero, and schedule the `tick` function to be called within 1000 milliseconds.
+We also configure the model to call the `resetCounter` method whenever it receives a `reset` event within the `this.id` scope.
+It's a common practice to use `this.id` to indicate that this particular model's `count` has been changed or requested to be reset.
+
+Whenever the counter is changed, either in the `resetCounter` or in the `tick` methods, it publishes a `count` event.
+
+Note that after the `tick` function is called, it schedules its next call, just like when the object was initialized.
 
 ```
 class CounterModel extends Croquet.Model {
@@ -44,11 +51,22 @@ class CounterModel extends Croquet.Model {
  tick() {
     this.count += 1;
     this.publish(this.id, "count");
+    this.future(1000).tick();
   }
 }
 ```
 
-After the model, we define `CounterApp` as our top level React component. In it, we use the `InCroquetSession` component, which takes the role of `Session.join` in `@croquet/croquet`, takes the same parameters and then provides the running Croquet session to its child components. We use Vite's feature to configure parameters. You can use different mechanismsor just hardcode your configuration if you use a different bundler.
+After defining the model, we have to register it in the Croquet framework.
+
+```
+CounterModel.register("CounterModel");
+```
+
+Now, we define the `CounterApp`, which will be our top level React component.
+We use the `InCroquetSession` component to provide the running Croquet session to its children.
+This component takes the role of the `Session.join` method in `@croquet/croquet`, and can be configured with the same parameters.
+We recommend using environment variables to configure them.
+If you use a different bundler, check their documentation on how to set them up.
 
 ```
 function CounterApp() {
@@ -67,48 +85,56 @@ function CounterApp() {
 }
 ```
 
-Next, we define the `CounterDisplay` component, which has two goals:
+Next, we define the `CounterDisplay` component, which represents a view of the model defined above.
+For now, it only has the logic to render the live count of the replicated counter.
 
- - Rendering the live count of the replicated counter
- - Resetting the counter on click
+We use the `useModelRoot` hook to get hold of the `CounterModel` in our session, and use its `count` attribute to initialize the component's state, with the `useState` hook.
+Then, we use the `useSubscribe` hook to listen to `count` events within the `model.id`'s scope.
+Note that the passed callback sets the `count` state to the value defined in the model.
+Finally, the component simply returns the value of the stored counter to display its value. 
 
 ```
- function CounterDisplay() {
+function CounterDisplay() {
   const model = useModelRoot();
+  const [count, setCount] = useState(model.count);
+
+  useSubscribe(model.id, "count", () => setCount(model.count), []);
+
+  return <div>{count}</div>;
+}
 ```
 
-First, we use the `useModelRoot` hook to get hold of the `CounterModel` in our session.
-Next, we create a state with the `useState` hook. Then, we set up subscription for the counter message, and set the state.
 
-If we just want to render the up-to-date count, we can finish our component with
+To explore how we can have information flow back from our component to the `CounterModel`, let's set up our component to reset the counter when we click the count.
 
-```
-return <div>{count}</div>;
-```
+First, we create a function `publishReset` that will publish a `reset` event to the `model.id` scope, which our `CounterModel` listens to.
+All that's left to do is to pass this function as `onClick` handler of our returned count element.
+Let's also add some styles to make the count more prominent.
 
-But, to explore how we can have information flow back from our component to the `CounterModel`, let's set up our component to reset the counter when we click the count.
-
-First, we create a callback that will publish the corresponding event like this.
+The final code should look like this:
 
 ```
-const publishReset = usePublish(() => [model.id, "reset"]);
+function CounterDisplay() {
+  const model = useModelRoot();
+  const [count, setCount] = useState(model.count);
+
+  useSubscribe(model.id, "count", () => setCount(model.count), []);
+
+  // Update the lines below
+  const publishReset = usePublish(() => [model.id, "reset"], []);
+
+  return (
+    <div
+      onClick={publishReset}
+      style={{ margin: "1em", fontSize: "3em", cursor: "pointer" }}
+    >
+      {count}
+    </div>
+  );
+}
 ```
 
-When we call `publishReset()`, it will publish a "reset" event to the `model.id` scope, which our `CounterModel` listens to.
-
-All that's left to do is to use this callback in the onClick handler of our returned count element. Let's also add some styles to make the count more prominent.
-
-```
-return (
-<div
-    onClick={publishReset}
-    style={{ margin: "1em", fontSize: "3em", cursor: "pointer" }}
->
-    {count}
-</div>
-);
-```
-
-Now, you should see a live ticking counter, which resets when you click it. You can open the URL shown in the preview section of the CodeSandbox embed in another tab or window and you should see the same live replicated counter as a second session participant.
+Now, you should see a live ticking counter, which resets when you click it.
+If you open the same page in another tab or window, you should see the same live replicated counter as a second session participant.
 
 To see a more interesting multi-user interaction, check out the next tutorial, where we implement a simple multiplayer music box.

--- a/docs/tutorials/1_React_Simple_Counter.md
+++ b/docs/tutorials/1_React_Simple_Counter.md
@@ -19,6 +19,7 @@ import {
   usePublish,
   useModelRoot,
   CroquetRoot,
+  App as CroquetApp,
   useSubscribe,
   Model
 } from "@croquet/react";


### PR DESCRIPTION
I left some suggestions to improve the Counter Tutorial. There are two questions that I would like to discuss with you:

1. When we configure the `InCroquetSession` component, I feel it would be better if we omitted that people could hard code the configuration values, and only showed how to use the env variables. I feel it's better if we encourage good practices, but I would like to hear your thoughts on this. I also noticed the `password` parameter in the `InCroquetSession` configuration is hardcoded to `'abc'`. Should we change it to be an env variable as well?
2. I started changing the markdown paragraphs to have one sentence per line, since it does not affect the markdown output, and makes it easier to see what changed in future iterations. I only did this in paragraphs with updated content, so that you only see what actually changed in the tutorial. Do you want to keep this suggestion? If so, should I update immediately the other lines?